### PR TITLE
PPL-29446 allow override of schemaRegistryUrls via runtime env property

### DIFF
--- a/src/main/java/io/zonky/kafka/registry/compatibility/mojo/TestSchemaCompatibilityMojo.java
+++ b/src/main/java/io/zonky/kafka/registry/compatibility/mojo/TestSchemaCompatibilityMojo.java
@@ -78,8 +78,13 @@ public class TestSchemaCompatibilityMojo extends AbstractMojo {
 
     /**
      * URLs to remote schema registry/registries.
+     * <p/>
+     * Typically configured in pom.xml (<code>plugin -> configuration -> schemaRegistryUrls</code>).
+     * <p/>
+     * Can also be overridden via runtime environment property <code>-Dschema-registry-compatibility-plugin.schema-registry-urls=http://some.url</code>
+     *
      */
-    @Parameter(required = true)
+    @Parameter(property = "schema-registry-compatibility-plugin.schema-registry-urls", required = true)
     private List<String> schemaRegistryUrls = new LinkedList<>();
 
     /**


### PR DESCRIPTION
Allows to override plugin configuration from `pom.xml` using -D runtime env property. For example:

```
mvn -Pschema-registry-compatibility-check -Dschema-registry-compatibility-plugin.schema-registry-urls=https://some-schema-registry.somedomain.com io.zonky:schema-registry-compatibility-plugin:1.0.3-SNAPSHOT:test-compatibility
```

